### PR TITLE
CompilerTemplate: partially rewrite loopy.ld

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
 __pycache__/
 *.py[cod]
 *$py.class
-*.sav
-*.elf

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 __pycache__/
 *.py[cod]
 *$py.class
+*.sav
+*.elf

--- a/CompilerTemplate/.gitignore
+++ b/CompilerTemplate/.gitignore
@@ -3,3 +3,5 @@ bin/
 *.bin
 *.nib
 *.o
+*.sav
+*.elf

--- a/CompilerTemplate/Makefile
+++ b/CompilerTemplate/Makefile
@@ -18,14 +18,14 @@ ROMPADDING = 0
 
 # Toolchain programs
 WONDERFUL_TOOLCHAIN ?= /opt/wonderful
-TOOLBIN ?= $(WONDERFUL_TOOLCHAIN)/toolchain/gcc-sh-elf/bin
-#TOOLBIN = /usr/local/bin
+TOOLBIN ?= $(WONDERFUL_TOOLCHAIN)/toolchain/gcc-sh-elf/bin/
+#TOOLBIN =
 PREFIX ?= sh-elf-
 #PREFIX = sh1-none-elf-
-CC  = $(TOOLBIN)/$(PREFIX)gcc
-CXX = $(TOOLBIN)/$(PREFIX)g++
-LD  = $(TOOLBIN)/$(PREFIX)ld
-OBJ = $(TOOLBIN)/$(PREFIX)objcopy
+CC  = $(TOOLBIN)$(PREFIX)gcc
+CXX = $(TOOLBIN)$(PREFIX)g++
+LD  = $(TOOLBIN)$(PREFIX)ld
+OBJ = $(TOOLBIN)$(PREFIX)objcopy
 
 # File manipulation progs
 MV     = mv
@@ -86,12 +86,8 @@ $(ROMSWP): $(ROM)
 %.bin: %.elf
 	$(OBJ) -O binary $< $@
 	$(FIXSUM) $(ROM)
-# pad the rom to an even multiple of 4096 bytes; this is to work
-# around a bug in map_pagetable in LoopyMSE. If that bug is fixed,
-# this can be removed.
-	truncate -s%4096 $(ROM)
 
-rom.elf: $(OBJS_S) $(OBJS_C)
+$(ROM:.bin=.elf): $(OBJS_S) $(OBJS_C)
 
 $(OBJDIR)/%.o: $(SRCDIR)/%.s | $(OBJDIR)
 	$(CC) $(CFLAGS) -c $< -o $@

--- a/CompilerTemplate/Makefile
+++ b/CompilerTemplate/Makefile
@@ -3,7 +3,6 @@
 
 # Normal use: "make clean && make"
 # Generate byteswapped ROM for bad flashers: "make clean && make swapped"
-
 # Memory sizes; should use K/M suffix or decimal integer
 # Cart rom, maximum 4MB addressable
 ROMSIZE = 4M
@@ -19,10 +18,14 @@ ROMPADDING = 0
 
 # Toolchain programs
 WONDERFUL_TOOLCHAIN ?= /opt/wonderful
-TOOLBIN = $(WONDERFUL_TOOLCHAIN)/toolchain/gcc-sh-elf/bin
-CC  = $(TOOLBIN)/sh-elf-gcc
-LD  = $(TOOLBIN)/sh-elf-ld
-OBJ = $(TOOLBIN)/sh-elf-objcopy
+TOOLBIN ?= $(WONDERFUL_TOOLCHAIN)/toolchain/gcc-sh-elf/bin
+#TOOLBIN = /usr/local/bin
+PREFIX ?= sh-elf-
+#PREFIX = sh1-none-elf-
+CC  = $(TOOLBIN)/$(PREFIX)gcc
+CXX = $(TOOLBIN)/$(PREFIX)g++
+LD  = $(TOOLBIN)/$(PREFIX)ld
+OBJ = $(TOOLBIN)/$(PREFIX)objcopy
 
 # File manipulation progs
 MV     = mv
@@ -39,7 +42,7 @@ ROMSWP = ./rom.nib
 
 # Basic compile options
 OPTIMIZE = -Os
-LIBS = -lm
+LIBS =
 
 # Below here probably doesn't need to be touched
 
@@ -51,10 +54,21 @@ OBJS_C  = $(patsubst $(SRCDIR)/%.c,$(OBJDIR)/%.o,$(SRCS_C))
 SRCS_S  = $(wildcard $(SRCDIR)/*.s)
 OBJS_S  = $(patsubst $(SRCDIR)/%.s,$(OBJDIR)/%.o,$(SRCS_S))
 
-SIZEDEFS  = -Wl,--defsym=ROMSIZE=$(ROMSIZE),--defsym=SRAMSIZE=$(SRAMSIZE),--defsym=STACKSIZE=$(STACKSIZE),--defsym=ROMPADDING=$(ROMPADDING)
+CFLAGS   = $(OPTIMIZE) -g -gdwarf-4
+CFLAGS  += -m1 -mrenesas
+CFLAGS  += -ffreestanding
+CFLAGS  += -falign-functions=4 -ffunction-sections -fdata-sections
+CFLAGS  += -fomit-frame-pointer -fno-asynchronous-unwind-tables -fno-unwind-tables
+CFLAGS  += -Wstack-usage=$(shell numfmt --from=iec $(STACKSIZE)) -I$(INCDIR)
 
-CFLAGS  = -m1 -mrenesas $(OPTIMIZE) -fomit-frame-pointer -fno-exceptions -fno-asynchronous-unwind-tables -fno-unwind-tables -nostartfiles -Wstack-usage=$(shell numfmt --from=iec $(STACKSIZE)) -I$(INCDIR) -flto
-LDFLAGS = $(SIZEDEFS) -Wl,-T $(LDSCRIPT) -nostartfiles $(LIBS)
+CXXFLAGS  = -std=c++23 -fno-exceptions -fno-non-call-exceptions -fno-rtti -fno-threadsafe-statics
+
+SIZEDEFS  = -Wl,--defsym=ROMSIZE=$(ROMSIZE)
+SIZEDEFS += -Wl,--defsym=SRAMSIZE=$(SRAMSIZE)
+SIZEDEFS += -Wl,--defsym=STACKSIZE=$(STACKSIZE)
+
+LDFLAGS  = -nostartfiles -nolibc -Wl,--gc-sections -Wl,--no-warn-rwx-segment -Wl,--orphan-handling=error -Wl,--print-memory-usage
+LDFLAGS += $(SIZEDEFS) -Wl,-T $(LDSCRIPT) $(LIBS)
 
 .PHONY: clean rom swapped
 
@@ -66,18 +80,26 @@ swapped: $(ROMSWP)
 $(ROMSWP): $(ROM)
 	$(OBJ) --reverse-bytes=2 -I binary -O binary $(ROM) $(ROMSWP)
 
-$(ROM): $(OBJS_S) $(OBJS_C)
+%.elf:
 	$(CC) $(LDFLAGS) $^ -o $@
+
+%.bin: %.elf
+	$(OBJ) -O binary $< $@
 	$(FIXSUM) $(ROM)
-ifeq ($(ROMPADDING), 1)
-	$(OBJ) --pad-to=$(shell numfmt --from=iec $(ROMSIZE)) -I binary -O binary $(ROM)
-endif
+# pad the rom to an even multiple of 4096 bytes; this is to work
+# around a bug in map_pagetable in LoopyMSE. If that bug is fixed,
+# this can be removed.
+	truncate -s%4096 $(ROM)
+
+rom.elf: $(OBJS_S) $(OBJS_C)
 
 $(OBJDIR)/%.o: $(SRCDIR)/%.s | $(OBJDIR)
 	$(CC) $(CFLAGS) -c $< -o $@
 $(OBJDIR)/%.o: $(SRCDIR)/%.c | $(OBJDIR)
 	$(CC) $(CFLAGS) -c $< -o $@
-	
+$(OBJDIR)/%.o: $(SRCDIR)/%.cpp | $(OBJDIR)
+	$(CXX) $(CFLAGS) $(CXXFLAGS) -c $< -o $@
+
 $(OBJDIR):
 	$(MKDIR) $@
 

--- a/CompilerTemplate/src/crt0.c
+++ b/CompilerTemplate/src/crt0.c
@@ -28,7 +28,7 @@ void crt_init(void)
   end = &__data_link_end;
   load = &__data_load_start;
   while (start < end) {
-    *load++ = *start++;
+    *start++ = *load++;
   };
 
   start = &__ctors_link_start;

--- a/CompilerTemplate/src/crt0.c
+++ b/CompilerTemplate/src/crt0.c
@@ -8,7 +8,7 @@ extern uint32_t __ctors_link_end __asm("__ctors_link_end");
 
 extern uint32_t __data_link_start __asm("__data_link_start");
 extern uint32_t __data_link_end __asm("__data_link_end");
-extern uint32_t __data_load_start __asm("__data_link_start");
+extern uint32_t __data_load_start __asm("__data_load_start");
 
 typedef void(init_t)(void);
 

--- a/CompilerTemplate/src/crt0.c
+++ b/CompilerTemplate/src/crt0.c
@@ -1,0 +1,39 @@
+#include <stdint.h>
+
+extern uint32_t __bss_link_start __asm("__bss_link_start");
+extern uint32_t __bss_link_end __asm("__bss_link_end");
+
+extern uint32_t __ctors_link_start __asm("__ctors_link_start");
+extern uint32_t __ctors_link_end __asm("__ctors_link_end");
+
+extern uint32_t __data_link_start __asm("__data_link_start");
+extern uint32_t __data_link_end __asm("__data_link_end");
+extern uint32_t __data_load_start __asm("__data_link_start");
+
+typedef void(init_t)(void);
+
+void crt_init(void)
+{
+  uint32_t * start;
+  uint32_t * end;
+  uint32_t * load;
+
+  start = &__bss_link_start;
+  end = &__bss_link_end;
+  while (start < end) {
+    *start++ = 0;
+  }
+
+  start = &__data_link_start;
+  end = &__data_link_end;
+  load = &__data_load_start;
+  while (start < end) {
+    *load++ = *start++;
+  };
+
+  start = &__ctors_link_start;
+  end = &__ctors_link_end;
+  while (start < end) {
+    ((init_t*)(*start++))();
+  }
+}

--- a/CompilerTemplate/src/startup.s
+++ b/CompilerTemplate/src/startup.s
@@ -1,42 +1,32 @@
-    .globl start
+    .section .header.pointers
+    .long __clheader_romfirst
+    .long __clheader_romlast
+    .long 0xa5a5a5a5 /* Placeholder checksum */
+    .long 0xffffffff
+    .long __clheader_sramfirst
+    .long __clheader_sramlast
+    .long 0xfffffffe
 
     ! NOT REQUIRED, and you can put anything you want here.
     ! Can move to a separate .s file keeping the .section line.
     ! Example in the format of Wanwan header:
-!    .section .copyright
+!    .section .header.copyright
 !    .long 0
 !    .asciz "(C)1995 GAZIO All right reserved."
 !    .asciz "ver 5.51"
 
 
     .section .text.startup
-
+    .globl start
 start:
     ! Set up initial stack pointer
     mov.l stackaddr, r15
     mov #0, r0
 
-    ! Clear .bss area in memory
-    mov.l clear_bss_start, r1
-    mov.l clear_bss_end, r2
-
-clear_bss_loop:
-    mov.w r0, @r1
-    add #2, r1
-    cmp/hs r2, r1
-    bf clear_bss_loop
-
-    ! Copy .data into memory
-    mov.l copy_data_from, r1
-    mov.l copy_data_to, r2
-    mov.l copy_data_end, r3
-    
-copy_data_loop:
-    mov.w @r1+, r0
-    mov.w r0, @r2
-    add #2, r2
-    cmp/hs r3, r2
-    bf copy_data_loop
+    ! Initialize bss, data, and ctors
+    mov.l crtinitaddr, r0
+    jsr @r0
+    nop
 
     ! Setup VBR
     mov.l vbraddr, r1
@@ -53,20 +43,12 @@ terminated:
     nop
 
     .align 4
-clear_bss_start:
-    .long __bss_start
-clear_bss_end:
-    .long __bss_end
-copy_data_from:
-    .long __text_end
-copy_data_to:
-    .long __data_start
-copy_data_end:
-    .long __data_end
 stackaddr:
     .long __stack_end
 vbraddr:
-    .long __vbr_start
+    .long __vbr_link_start
+crtinitaddr:
+    .long _crt_init
 mainaddr:
     .long _main
 

--- a/CompilerTemplate/src/vectors.c
+++ b/CompilerTemplate/src/vectors.c
@@ -11,6 +11,7 @@ __attribute__((interrupt_handler))
 __attribute__((section(".smallfunc")))
 void doNothing(void) { /*asm volatile ("nop");*/ }
 
+__attribute__((noreturn))
 __attribute__((interrupt_handler))
 __attribute__((section(".smallfunc")))
 void halt(void) { while(1); }

--- a/CompilerTemplate/tools/debug.ld
+++ b/CompilerTemplate/tools/debug.ld
@@ -1,0 +1,48 @@
+  /* Stabs debugging sections.  */
+  .stab          0 : { *(.stab) }
+  .stabstr       0 : { *(.stabstr) }
+  .stab.excl     0 : { *(.stab.excl) }
+  .stab.exclstr  0 : { *(.stab.exclstr) }
+  .stab.index    0 : { *(.stab.index) }
+  .stab.indexstr 0 : { *(.stab.indexstr) }
+  .comment       0 : { *(.comment) }
+  .gnu.build.attributes : { *(.gnu.build.attributes .gnu.build.attributes.*) }
+  /* DWARF debug sections.
+     Symbols in the DWARF debugging sections are relative to the beginning
+     of the section so we begin them at 0.  */
+  /* DWARF 1.  */
+  .debug          0 : { *(.debug) }
+  .line           0 : { *(.line) }
+  /* GNU DWARF 1 extensions.  */
+  .debug_srcinfo  0 : { *(.debug_srcinfo) }
+  .debug_sfnames  0 : { *(.debug_sfnames) }
+  /* DWARF 1.1 and DWARF 2.  */
+  .debug_aranges  0 : { *(.debug_aranges) }
+  .debug_pubnames 0 : { *(.debug_pubnames) }
+  /* DWARF 2.  */
+  .debug_info     0 : { *(.debug_info .gnu.linkonce.wi.*) }
+  .debug_abbrev   0 : { *(.debug_abbrev) }
+  .debug_line     0 : { *(.debug_line .debug_line.* .debug_line_end) }
+  .debug_frame    0 : { *(.debug_frame) }
+  .debug_str      0 : { *(.debug_str) }
+  .debug_loc      0 : { *(.debug_loc) }
+  .debug_macinfo  0 : { *(.debug_macinfo) }
+  /* SGI/MIPS DWARF 2 extensions.  */
+  .debug_weaknames 0 : { *(.debug_weaknames) }
+  .debug_funcnames 0 : { *(.debug_funcnames) }
+  .debug_typenames 0 : { *(.debug_typenames) }
+  .debug_varnames  0 : { *(.debug_varnames) }
+  /* DWARF 3.  */
+  .debug_pubtypes 0 : { *(.debug_pubtypes) }
+  .debug_ranges   0 : { *(.debug_ranges) }
+  /* DWARF 5.  */
+  .debug_addr     0 : { *(.debug_addr) }
+  .debug_line_str 0 : { *(.debug_line_str) }
+  .debug_loclists 0 : { *(.debug_loclists) }
+  .debug_macro    0 : { *(.debug_macro) }
+  .debug_names    0 : { *(.debug_names) }
+  .debug_rnglists 0 : { *(.debug_rnglists) }
+  .debug_str_offsets 0 : { *(.debug_str_offsets) }
+  .debug_sup      0 : { *(.debug_sup) }
+  .gnu.attributes 0 : { KEEP (*(.gnu.attributes)) }
+  /DISCARD/ : { *(.note.GNU-stack) *(.gnu_debuglink) *(.gnu.lto_*) *(.rela.*) }

--- a/CompilerTemplate/tools/loopy.ld
+++ b/CompilerTemplate/tools/loopy.ld
@@ -92,7 +92,7 @@ SECTIONS {
 }
 
 __clheader_romfirst = ADDR(.vectors);
-__clheader_romlast = ORIGIN(ROM) + LENGTH(ROM) - 2;
+__clheader_romlast = LOADADDR(.data) + SIZEOF(.data) - 2;
 __clheader_sramfirst = ORIGIN(SRAM);
 __clheader_sramlast = ORIGIN(SRAM) + LENGTH(SRAM) - 1;
 

--- a/CompilerTemplate/tools/loopy.ld
+++ b/CompilerTemplate/tools/loopy.ld
@@ -1,80 +1,103 @@
 /* Import ROMSIZE, SRAMSIZE, STACKSIZE, ROMPADDING(bool) */
 /* ROMPADDING value is just used to build header properly */
 
+OUTPUT_FORMAT("elf32-sh", "elf32-sh", "elf32-sh")
 OUTPUT_ARCH(sh)
-OUTPUT_FORMAT("binary")
 
 MEMORY {
     /* Console side */
-    RAM (rwx) : ORIGIN = 0x09000000, LENGTH = 512K
+    RAM (rwx) : ORIGIN = 0x09000000, LENGTH = 512K - STACKSIZE
     /* Cartridge side */
     ROM (rwx) : ORIGIN = 0x0E000000, LENGTH = ROMSIZE
     SRAM (rwx) : ORIGIN = 0x02000000, LENGTH = SRAMSIZE
 }
 
 SECTIONS {
-  .clheader : {
-    LONG(__clheader_romfirst)
-    LONG(__clheader_romlast)
-    LONG(0xA5A5A5A5) /* Placeholder checksum */
-    LONG(-1)
-    LONG(__clheader_sramfirst)
-    LONG(__clheader_sramlast)
-    LONG(-2)
-    KEEP(*(.copyright))
+  . = ORIGIN(ROM);
+
+  .header : {
+    KEEP(*(.header.pointers))
+    KEEP(*(.header.copyright))
+
     . = 0x80;
   } >ROM =0xFF
   
-  .vectors : ALIGN(4) {
+  .vectors ALIGN(4) : SUBALIGN(4) {
     KEEP(*(.vectors))
+
     . = 0x1D0;
+
     /* 560 bytes spare in vectable, put small functions here */
     KEEP(*(.lowfunc))
     KEEP(*(.smallfunc))
-    . = 0x400;
   } >ROM =0xFF
-  
-  .text : {
-    __text_start = .;
+
+  . = ORIGIN(ROM) + 0x480;
+
+  .text ALIGN(4) : SUBALIGN(4)
+  {
     *(.text.startup)
-    *(.text .text.*)
-    *(.rodata .rodata.*)
-    . = ALIGN(4);
-    __text_end = .;
+    *(.text)
+    *(.text.*)
+
   } >ROM =0xFF
-  
-  .bss (NOLOAD) : {
-    /* Reserve low RAM for BIOS */
-    . = 0x100;
-    __bss_start = . ;
-    *(.bss .bss.*)
-    *(COMMON)
-    . = ALIGN(4);
-    __bss_end = . ;
-  } >RAM
-  
-  .init : AT(__text_end) {
-    . = ALIGN(4);
-    __data_start = .;
-    *(.data*)
+
+  __text_link_start = ADDR(.text);
+  __text_link_end = ADDR(.text) + SIZEOF(.text);
+
+  .rodata ALIGN(4) : SUBALIGN(4) {
+    *(.rodata)
+    *(.rodata.*)
+  } >ROM
+
+  __rodata_link_start = ADDR(.rodata);
+  __rodata_link_end = ADDR(.rodata) + SIZEOF(.rodata);
+
+  .ctors ALIGN(4) : SUBALIGN(4)
+  {
+    KEEP(*(.ctors))
+    KEEP(*(.ctors.*))
+  } >ROM
+
+    . = ALIGN(4096);
+
+  __ctors_link_start = ADDR(.ctors);
+  __ctors_link_end = ADDR(.ctors) + SIZEOF(.ctors);
+
+  /* reserve 256 bytes at the beginning of RAM for the BIOS */
+  . = ORIGIN(RAM) + 0x100;
+
+  .data ALIGN(4) : SUBALIGN(4) {
+    *(.data)
+    *(.data.*)
+
     KEEP(*(.ramtext))
     KEEP(*(.ramfunc))
-    . = ALIGN(4);
-    __data_end = .;
+  } >RAM AT> ROM
+
+  __data_link_start = ADDR(.data);
+  __data_link_end = ADDR(.data) + SIZEOF(.data);
+  __data_load_start = LOADADDR(.data);
+
+  .bss ALIGN(4) (NOLOAD) : SUBALIGN(4) {
+    *(.bss)
+    *(.bss.*)
+    *(COMMON)
   } >RAM
-  
-  .stack : {
-    . = ORIGIN(RAM)+LENGTH(RAM)-STACKSIZE;
-    /*__stack_start = .;*/
-    . = . + STACKSIZE;
-    __stack_end = .;
-  } >RAM
+
+  __bss_link_start = ADDR(.bss);
+  __bss_link_end = ADDR(.bss) + SIZEOF(.bss);
+
+  INCLUDE "tools/debug.ld"
 }
 
-__vbr_start = ADDR(.vectors);
-__clheader_romfirst = __vbr_start;
-__clheader_romlast = (ROMPADDING ? ORIGIN(ROM) + LENGTH(ROM) : __text_end + SIZEOF(.init)) - 2;
+__clheader_romfirst = ADDR(.vectors);
+__clheader_romlast = ORIGIN(ROM) + LENGTH(ROM) - 2;
 __clheader_sramfirst = ORIGIN(SRAM);
 __clheader_sramlast = ORIGIN(SRAM) + LENGTH(SRAM) - 1;
 
-ENTRY(__text_start);
+__stack_end = ORIGIN(RAM) + LENGTH(RAM) + STACKSIZE;
+
+__vbr_link_start = ADDR(.vectors);
+
+ENTRY(start);


### PR DESCRIPTION
- moved C-runtime initialization to crt0.c

- C-runtime initialization now includes C++ static initializers

- added C++ Makefile rule

- rom building is split to "elf" and "bin" parts; this makes it easier to view the outcome of running the linker script

- copy-pasted DWARF debugging sections from the default gcc linker script in a new "debug.ld" script keep things clean--without this, debugging information would not be included in the linker script output.

- enabled debugging information (line numbers, symbols, source code) for all compiler output

- none of the generated debugging information is included in the final binary--rom size requirements are unaffected

- generally rearranged and reformatted loopy.ld

- enabled -ffunction-sections, -fdata-sections, and --gc-sections. This has the effect that functions or data that are not referenced/reachable by the entry point (excluding KEEP() sections) are removed at link-time. This can be convenient for larger projects with somewhat lazily-maintained Makefiles.

- enabled link-time errors for unlinked sections. For example, this means that if one attempts to use C++ static destructors (what is the point in this case?), linking will fail with a message saying the static destructor input section is not placed by the linker script in any output section.

- improved the "stack reservation overlaps with static memory" concept in the linker script--this is now just subtracted from total RAM.

- enabled --print-memory-usage, to display static memory allocations.

I believe I preserved all of the behavior that was intended in the original linker script. I briefly tested this with a trivial example Loopy program, and compared the output of these changes byte-for-byte with a rom produced prior to these changes, and compared load-time static RAM allocation, and verified the stack pointer address is indeed at the end of RAM, but did not test farther than that.