### PR TITLE
loopy.ld: add LMA alignment statements

### DIFF
--- a/CompilerTemplate/tools/loopy.ld
+++ b/CompilerTemplate/tools/loopy.ld
@@ -39,6 +39,13 @@ SECTIONS {
     *(.text)
     *(.text.*)
 
+    /*
+    This and the following `. = ALIGN(4)` expressions are intended to
+    encourage LMA alignment. Without this, the load addresses of AT>
+    sections such as .data can be misaligned, causes issues in crt0.c
+    if `.data` is copied using 32-bit reads/writes.
+    */
+    . = ALIGN(4);
   } >ROM =0xFF
 
   __text_link_start = ADDR(.text);
@@ -47,6 +54,8 @@ SECTIONS {
   .rodata ALIGN(4) : SUBALIGN(4) {
     *(.rodata)
     *(.rodata.*)
+
+    . = ALIGN(4);
   } >ROM
 
   __rodata_link_start = ADDR(.rodata);
@@ -56,6 +65,8 @@ SECTIONS {
   {
     KEEP(*(.ctors))
     KEEP(*(.ctors.*))
+
+    . = ALIGN(4);
   } >ROM
 
   __ctors_link_start = ADDR(.ctors);
@@ -70,6 +81,8 @@ SECTIONS {
 
     KEEP(*(.ramtext))
     KEEP(*(.ramfunc))
+
+    . = ALIGN(4);
   } >RAM AT> ROM
 
   __data_link_start = ADDR(.data);
@@ -80,6 +93,8 @@ SECTIONS {
     *(.bss)
     *(.bss.*)
     *(COMMON)
+
+    . = ALIGN(4);
   } >RAM
 
   __bss_link_start = ADDR(.bss);


### PR DESCRIPTION
This exclusively affects output sections that use the `AT>` keyword.

ld appears to have curious behavior where the alignment requirements of a section only respected as a coincidence of the case where LMA==VMA. If an alternate LMA is specified with AT> , alignment requirements are completely ignored when the LMA is created.

In the case of loopy.ld, if (the last input section of) .rodata has a size that is not an even multiple of 4, and the size of .ctors is zero, the LMA chosen for .data will be an odd/unaligned address.

There does not appear to be a convenient way to convince the linker to preserve the section's alignment requirements when an AT> LMA is chosen.

In an attempt to try to generate correct LMAs, this adds the statement:

  . = ALIGN(4)

to the end of every output section prior to .data. This causes each output section to have a size that is a multiple of 4.

I verified that this indeed appears to prevent LMA misalignment for output sections that use the AT> keyword.